### PR TITLE
Handle Null API responses

### DIFF
--- a/fixtures/vcr_cassettes/external_service/valid_service_returning_null.yml
+++ b/fixtures/vcr_cassettes/external_service/valid_service_returning_null.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://my_moodle_instance.com/webservice/rest/server.php?enrolments%5B0%5D%5Buserid%5D=11157&enrolments%5B0%5D%5Broleid%5D=5&enrolments%5B0%5D%5Bcourseid%5D=282&moodlewsrestformat=json&wsfunction=enrol_manual_enrol_users&wstoken=mytoken
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Accept:
+      - json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 14 Jul 2015 12:07:53 GMT
+      Server:
+      - Apache
+      Cache-Control:
+      - private, must-revalidate, pre-check=0, post-check=0, max-age=0
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Accept-Ranges:
+      - none
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '4'
+      Content-Type:
+      - application/json
+    body:
+      encoding: UTF-8
+      string: 'null'
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: http://my_moodle_instance.com/webservice/rest/server.php?enrolments%5B0%5D%5Buserid%5D=11157&enrolments%5B0%5D%5Broleid%5D=5&enrolments%5B0%5D%5Bcourseid%5D=282&moodlewsrestformat=json&wsfunction=enrol_manual_enrol_users&wstoken=mytoken
+  recorded_at: Tue, 14 Jul 2015 12:07:55 GMT
+recorded_with: VCR 2.9.3

--- a/lib/moodle/api/request.rb
+++ b/lib/moodle/api/request.rb
@@ -37,8 +37,13 @@ module Moodle
         response_body.is_a?(Hash) && response_body['error']
       end
 
+      # API calls that return null are considered successful
       def response_body
-        JSON.parse(response.body)
+        begin
+          JSON.parse(response.body)
+        rescue JSON::ParserError => e
+          response.body
+        end
       end
     end
   end

--- a/spec/moodle/api/request_spec.rb
+++ b/spec/moodle/api/request_spec.rb
@@ -55,6 +55,24 @@ module Moodle::Api
           expect(response).to match_array([])
         end
       end
+
+      # Moodle API returns null in some cases for successful calls
+       it 'returns true if the response body is null' do
+        params =  {
+          'enrolments[0][userid]' => '11157',
+          'enrolments[0][roleid]' => '5',
+          'enrolments[0][courseid]' => '282',
+          'moodlewsrestformat' => 'json',
+          'wsfunction' => 'enrol_manual_enrol_users',
+          'wstoken' => 'mytoken'
+        }
+
+        VCR.use_cassette('external_service/valid_service_returning_null') do
+          response = Moodle::Api::Request.new.post(path, params: params, headers: headers)
+
+          expect(response).to eq('null')
+        end
+      end
     end
   end
 end

--- a/spec/moodle/api/request_spec.rb
+++ b/spec/moodle/api/request_spec.rb
@@ -57,7 +57,7 @@ module Moodle::Api
       end
 
       # Moodle API returns null in some cases for successful calls
-       it 'returns true if the response body is null' do
+       it 'returns null if the response body is null' do
         params =  {
           'enrolments[0][userid]' => '11157',
           'enrolments[0][roleid]' => '5',


### PR DESCRIPTION
Return the response body if null is returned by the moodle API. In so me cases Moodle will return null which means the api call was successful. This isn't ideal and hopefully gets updated in the Moodle API.